### PR TITLE
Nil checks -> guard

### DIFF
--- a/Source/Neon.swift
+++ b/Source/Neon.swift
@@ -260,8 +260,8 @@ extension UIView {
     ///
     func fillSuperview(left left: CGFloat = 0, right: CGFloat = 0, top: CGFloat = 0, bottom: CGFloat = 0) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         let width : CGFloat = superview.width() - (left + right)
@@ -283,8 +283,8 @@ extension UIView {
     ///
     func anchorInCenter(width width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         let xOrigin : CGFloat = (superview.width() / 2.0) - (width / 2.0)
@@ -311,8 +311,8 @@ extension UIView {
     ///
     func anchorInCorner(corner: Corner, xPad: CGFloat, yPad: CGFloat, width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         var xOrigin : CGFloat = 0.0
@@ -358,8 +358,8 @@ extension UIView {
     ///
     func anchorToEdge(edge: Edge, padding: CGFloat, width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         var xOrigin : CGFloat = 0.0
@@ -412,8 +412,8 @@ extension UIView {
     ///
     func anchorAndFillEdge(edge: Edge, xPad: CGFloat, yPad: CGFloat, otherSize: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         var xOrigin : CGFloat = 0.0
@@ -474,8 +474,8 @@ extension UIView {
     ///
     func align(align: Align, relativeTo sibling: UIView, padding: CGFloat, width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
       
         if self == sibling {
@@ -572,8 +572,8 @@ extension UIView {
     ///
     func alignAndFillWidth(align align: Align, relativeTo sibling: UIView, padding: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         if self == sibling {
@@ -687,8 +687,8 @@ extension UIView {
     ///
     func alignAndFillHeight(align align: Align, relativeTo sibling: UIView, padding: CGFloat, width: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         if self == sibling {
@@ -800,8 +800,8 @@ extension UIView {
     ///
     func alignAndFill(align align: Align, relativeTo sibling: UIView, padding: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         if self == sibling {
@@ -936,8 +936,8 @@ extension UIView {
     ///
     func alignBetweenHorizontal(align align: Align, primaryView: UIView, secondaryView: UIView, padding: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         if self == primaryView || self == secondaryView {
@@ -1018,8 +1018,8 @@ extension UIView {
     ///
     func alignBetweenVertical(align align: Align, primaryView: UIView, secondaryView: UIView, padding: CGFloat, width: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         if self == primaryView || self == secondaryView {
@@ -1104,8 +1104,8 @@ extension UIView {
     ///
     func groupInCenter(group group: Group, views: [UIView], padding: CGFloat, width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         if views.count == 0 {
@@ -1195,8 +1195,8 @@ extension UIView {
     ///
     func groupAgainstEdge(group group: Group, views: [UIView], againstEdge edge: Edge, padding: CGFloat, width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         if views.count == 0 {
@@ -1317,8 +1317,8 @@ extension UIView {
     ///
     func groupAndFill(group group: Group, views: [UIView], padding: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         if views.count == 0 {
@@ -1365,8 +1365,8 @@ extension UIView {
     //
     private func groupInCornerHorizontal(views: [UIView], inCorner corner: Corner, padding: CGFloat, width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         if views.count == 0 {
@@ -1413,8 +1413,8 @@ extension UIView {
 
     private func groupInCornerVertical(views: [UIView], inCorner corner: Corner, padding: CGFloat, width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         if views.count == 0 {
@@ -1461,8 +1461,8 @@ extension UIView {
 
     private func groupAndAlignHorizontal(align: Align, views: [UIView], relativeTo sibling: UIView, padding: CGFloat, width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         if views.count == 0 {
@@ -1552,8 +1552,8 @@ extension UIView {
 
     private func groupAndAlignVertical(align: Align, views: [UIView], relativeTo sibling: UIView, padding: CGFloat, width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-          print("[NEON] Warning: Can't anchor view without superview!")
-          return
+            print("[NEON] Warning: Can't anchor view without superview!")
+            return
         }
 
         if views.count == 0 {

--- a/Source/Neon.swift
+++ b/Source/Neon.swift
@@ -259,13 +259,13 @@ extension UIView {
     ///   - bottom: The padding between the bottom of the view and the superview.
     ///
     func fillSuperview(left left: CGFloat = 0, right: CGFloat = 0, top: CGFloat = 0, bottom: CGFloat = 0) {
-        if superview == nil {
-            print("[NEON] Warning: Can't anchor view without superview!")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
-        let width : CGFloat = superview!.width() - (left + right)
-        let height : CGFloat = superview!.height() - (top + bottom)
+        let width : CGFloat = superview.width() - (left + right)
+        let height : CGFloat = superview.height() - (top + bottom)
 
         frame = CGRectMake(left, top, width, height)
     }
@@ -282,13 +282,13 @@ extension UIView {
     ///   - height: The height of the view.
     ///
     func anchorInCenter(width width: CGFloat, height: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Can't anchor view without superview!")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
-        let xOrigin : CGFloat = (superview!.width() / 2.0) - (width / 2.0)
-        let yOrigin : CGFloat = (superview!.height() / 2.0) - (height / 2.0)
+        let xOrigin : CGFloat = (superview.width() / 2.0) - (width / 2.0)
+        let yOrigin : CGFloat = (superview.height() / 2.0) - (height / 2.0)
 
         frame = CGRectMake(xOrigin, yOrigin, width, height)
     }
@@ -310,9 +310,9 @@ extension UIView {
     ///   - height: The height of the view.
     ///
     func anchorInCorner(corner: Corner, xPad: CGFloat, yPad: CGFloat, width: CGFloat, height: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Can't anchor view without superview!")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
         var xOrigin : CGFloat = 0.0
@@ -325,15 +325,15 @@ extension UIView {
 
         case .BottomLeft:
             xOrigin = xPad
-            yOrigin = superview!.height() - height - yPad
+            yOrigin = superview.height() - height - yPad
 
         case .TopRight:
-            xOrigin = superview!.width() - width - xPad
+            xOrigin = superview.width() - width - xPad
             yOrigin = yPad
 
         case .BottomRight:
-            xOrigin = superview!.width() - width - xPad
-            yOrigin = superview!.height() - height - yPad
+            xOrigin = superview.width() - width - xPad
+            yOrigin = superview.height() - height - yPad
         }
 
         frame = CGRectMake(xOrigin, yOrigin, width, height)
@@ -357,9 +357,9 @@ extension UIView {
     ///   - height: The height of the view.
     ///
     func anchorToEdge(edge: Edge, padding: CGFloat, width: CGFloat, height: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Can't anchor view without superview!")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
         var xOrigin : CGFloat = 0.0
@@ -367,20 +367,20 @@ extension UIView {
 
         switch edge {
         case .Top:
-            xOrigin = (superview!.width() / 2.0) - (width / 2.0)
+            xOrigin = (superview.width() / 2.0) - (width / 2.0)
             yOrigin = padding
 
         case .Left:
             xOrigin = padding
-            yOrigin = (superview!.height() / 2.0) - (height / 2.0)
+            yOrigin = (superview.height() / 2.0) - (height / 2.0)
 
         case .Bottom:
-            xOrigin = (superview!.width() / 2.0) - (width / 2.0)
-            yOrigin = superview!.height() - height - padding
+            xOrigin = (superview.width() / 2.0) - (width / 2.0)
+            yOrigin = superview.height() - height - padding
 
         case .Right:
-            xOrigin = superview!.width() - width - padding
-            yOrigin = (superview!.height() / 2.0) - (height / 2.0)
+            xOrigin = superview.width() - width - padding
+            yOrigin = (superview.height() / 2.0) - (height / 2.0)
         }
 
         frame = CGRectMake(xOrigin, yOrigin, width, height)
@@ -411,9 +411,9 @@ extension UIView {
     /// automatically calculated.
     ///
     func anchorAndFillEdge(edge: Edge, xPad: CGFloat, yPad: CGFloat, otherSize: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Can't anchor view without superview!")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
         var xOrigin : CGFloat = 0.0
@@ -425,26 +425,26 @@ extension UIView {
         case .Top:
             xOrigin = xPad
             yOrigin = yPad
-            width = superview!.width() - (2 * xPad)
+            width = superview.width() - (2 * xPad)
             height = otherSize
 
         case .Left:
             xOrigin = xPad
             yOrigin = yPad
             width = otherSize
-            height = superview!.height() - (2 * yPad)
+            height = superview.height() - (2 * yPad)
 
         case .Bottom:
             xOrigin = xPad
-            yOrigin = superview!.height() - otherSize - yPad
-            width = superview!.width() - (2 * xPad)
+            yOrigin = superview.height() - otherSize - yPad
+            width = superview.width() - (2 * xPad)
             height = otherSize
 
         case .Right:
-            xOrigin = superview!.width() - otherSize - xPad
+            xOrigin = superview.width() - otherSize - xPad
             yOrigin = yPad
             width = otherSize
-            height = superview!.height() - (2 * yPad)
+            height = superview.height() - (2 * yPad)
         }
         
         frame = CGRectMake(xOrigin, yOrigin, width, height)
@@ -473,11 +473,11 @@ extension UIView {
     ///   - height: The height of the view.
     ///
     func align(align: Align, relativeTo sibling: UIView, padding: CGFloat, width: CGFloat, height: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Can't align view without superview!")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
-        
+      
         if self == sibling {
             fatalError("[NEON] Can't align view relative to itself!")
         }
@@ -571,9 +571,9 @@ extension UIView {
     ///   - height: The height of the view.
     ///
     func alignAndFillWidth(align align: Align, relativeTo sibling: UIView, padding: CGFloat, height: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Can't align view without superview!")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
         if self == sibling {
@@ -584,7 +584,7 @@ extension UIView {
             fatalError("[NEON] Can't align view relative to another view in a different superview!")
         }
 
-        let superviewWidth = superview!.width()
+        let superviewWidth = superview.width()
         var xOrigin : CGFloat = 0.0
         var yOrigin : CGFloat = 0.0
         var width : CGFloat = 0.0
@@ -686,9 +686,9 @@ extension UIView {
     ///   - width: The width of the view.
     ///
     func alignAndFillHeight(align align: Align, relativeTo sibling: UIView, padding: CGFloat, width: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Can't align view without superview!")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
         if self == sibling {
@@ -699,7 +699,7 @@ extension UIView {
             fatalError("[NEON] Can't align view relative to another view in a different superview!")
         }
 
-        let superviewHeight = superview!.height()
+        let superviewHeight = superview.height()
         var xOrigin : CGFloat = 0.0
         var yOrigin : CGFloat = 0.0
         var height : CGFloat = 0.0
@@ -799,9 +799,9 @@ extension UIView {
     ///   - padding: The padding to be applied between this view, the sibling view and the superview.
     ///
     func alignAndFill(align align: Align, relativeTo sibling: UIView, padding: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Can't align view without superview!")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
         if self == sibling {
@@ -812,8 +812,8 @@ extension UIView {
             fatalError("[NEON] Can't align view relative to another view in a different superview!")
         }
 
-        let superviewWidth = superview!.width()
-        let superviewHeight = superview!.height()
+        let superviewWidth = superview.width()
+        let superviewHeight = superview.height()
         var xOrigin : CGFloat = 0.0
         var yOrigin : CGFloat = 0.0
         var width : CGFloat = 0.0
@@ -935,9 +935,9 @@ extension UIView {
     ///   - height: The height of the view.
     ///
     func alignBetweenHorizontal(align align: Align, primaryView: UIView, secondaryView: UIView, padding: CGFloat, height: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Can't align view without superview!")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
         if self == primaryView || self == secondaryView {
@@ -948,7 +948,7 @@ extension UIView {
             fatalError("[NEON] Can't align view relative to another view in a different superview!")
         }
 
-        let superviewWidth : CGFloat = superview!.width()
+        let superviewWidth : CGFloat = superview.width()
         var xOrigin : CGFloat = 0.0
         var yOrigin : CGFloat = 0.0
         var width : CGFloat = 0.0
@@ -1017,9 +1017,9 @@ extension UIView {
     ///   - width: The width of the view.
     ///
     func alignBetweenVertical(align align: Align, primaryView: UIView, secondaryView: UIView, padding: CGFloat, width: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Can't align view without superview!")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
         if self == primaryView || self == secondaryView {
@@ -1030,7 +1030,7 @@ extension UIView {
             fatalError("[NEON] Can't align view relative to another view in a different superview!")
         }
 
-        let superviewHeight : CGFloat = superview!.height()
+        let superviewHeight : CGFloat = superview.height()
         var xOrigin : CGFloat = 0.0
         var yOrigin : CGFloat = 0.0
         var height : CGFloat = 0.0
@@ -1103,9 +1103,9 @@ extension UIView {
     ///   - height: The height of each subview.
     ///
     func groupInCenter(group group: Group, views: [UIView], padding: CGFloat, width: CGFloat, height: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Attempted to group subviews but view doesn't have a superview of its own.")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
         if views.count == 0 {
@@ -1194,9 +1194,9 @@ extension UIView {
     ///   - height: The height of each subview.
     ///
     func groupAgainstEdge(group group: Group, views: [UIView], againstEdge edge: Edge, padding: CGFloat, width: CGFloat, height: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Attempted to group subviews but view doesn't have a superview of its own.")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
         if views.count == 0 {
@@ -1316,9 +1316,9 @@ extension UIView {
     ///   - padding: The padding to be applied between each of the subviews and the sibling.
     ///
     func groupAndFill(group group: Group, views: [UIView], padding: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Attempted to group subviews but view doesn't have a superview of its own.")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
         if views.count == 0 {
@@ -1364,9 +1364,9 @@ extension UIView {
     // MARK: Private utils
     //
     private func groupInCornerHorizontal(views: [UIView], inCorner corner: Corner, padding: CGFloat, width: CGFloat, height: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Attempted to group subviews but view doesn't have a superview of its own.")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
         if views.count == 0 {
@@ -1412,9 +1412,9 @@ extension UIView {
     }
 
     private func groupInCornerVertical(views: [UIView], inCorner corner: Corner, padding: CGFloat, width: CGFloat, height: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Attempted to group subviews but view doesn't have a superview of its own.")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
         if views.count == 0 {
@@ -1460,9 +1460,9 @@ extension UIView {
     }
 
     private func groupAndAlignHorizontal(align: Align, views: [UIView], relativeTo sibling: UIView, padding: CGFloat, width: CGFloat, height: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Attempted to group subviews but view doesn't have a superview of its own.")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
         if views.count == 0 {
@@ -1551,9 +1551,9 @@ extension UIView {
     }
 
     private func groupAndAlignVertical(align: Align, views: [UIView], relativeTo sibling: UIView, padding: CGFloat, width: CGFloat, height: CGFloat) {
-        if superview == nil {
-            print("[NEON] Warning: Attempted to group subviews but view doesn't have a superview of its own.")
-            return
+        guard let superview = superview else {
+          print("[NEON] Warning: Can't anchor view without superview!")
+          return
         }
 
         if views.count == 0 {

--- a/Source/Neon.swift
+++ b/Source/Neon.swift
@@ -474,7 +474,7 @@ extension UIView {
     ///
     func align(align: Align, relativeTo sibling: UIView, padding: CGFloat, width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-            print("[NEON] Warning: Can't anchor view without superview!")
+            print("[NEON] Warning: Can't align view without superview!")
             return
         }
       
@@ -572,7 +572,7 @@ extension UIView {
     ///
     func alignAndFillWidth(align align: Align, relativeTo sibling: UIView, padding: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-            print("[NEON] Warning: Can't anchor view without superview!")
+            print("[NEON] Warning: Can't align view without superview!")
             return
         }
 
@@ -687,7 +687,7 @@ extension UIView {
     ///
     func alignAndFillHeight(align align: Align, relativeTo sibling: UIView, padding: CGFloat, width: CGFloat) {
         guard let superview = superview else {
-            print("[NEON] Warning: Can't anchor view without superview!")
+            print("[NEON] Warning: Can't align view without superview!")
             return
         }
 
@@ -800,7 +800,7 @@ extension UIView {
     ///
     func alignAndFill(align align: Align, relativeTo sibling: UIView, padding: CGFloat) {
         guard let superview = superview else {
-            print("[NEON] Warning: Can't anchor view without superview!")
+            print("[NEON] Warning: Can't align view without superview!")
             return
         }
 
@@ -936,7 +936,7 @@ extension UIView {
     ///
     func alignBetweenHorizontal(align align: Align, primaryView: UIView, secondaryView: UIView, padding: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-            print("[NEON] Warning: Can't anchor view without superview!")
+            print("[NEON] Warning: Can't align view without superview!")
             return
         }
 
@@ -1018,7 +1018,7 @@ extension UIView {
     ///
     func alignBetweenVertical(align align: Align, primaryView: UIView, secondaryView: UIView, padding: CGFloat, width: CGFloat) {
         guard let superview = superview else {
-            print("[NEON] Warning: Can't anchor view without superview!")
+            print("[NEON] Warning: Can't align view without superview!")
             return
         }
 
@@ -1104,7 +1104,7 @@ extension UIView {
     ///
     func groupInCenter(group group: Group, views: [UIView], padding: CGFloat, width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-            print("[NEON] Warning: Can't anchor view without superview!")
+            print("[NEON] Warning: Attempted to group subviews but view doesn't have a superview of its own.")
             return
         }
 
@@ -1195,7 +1195,7 @@ extension UIView {
     ///
     func groupAgainstEdge(group group: Group, views: [UIView], againstEdge edge: Edge, padding: CGFloat, width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-            print("[NEON] Warning: Can't anchor view without superview!")
+            print("[NEON] Warning: Attempted to group subviews but view doesn't have a superview of its own.")
             return
         }
 
@@ -1317,7 +1317,7 @@ extension UIView {
     ///
     func groupAndFill(group group: Group, views: [UIView], padding: CGFloat) {
         guard let superview = superview else {
-            print("[NEON] Warning: Can't anchor view without superview!")
+            print("[NEON] Warning: Attempted to group subviews but view doesn't have a superview of its own.")
             return
         }
 
@@ -1365,7 +1365,7 @@ extension UIView {
     //
     private func groupInCornerHorizontal(views: [UIView], inCorner corner: Corner, padding: CGFloat, width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-            print("[NEON] Warning: Can't anchor view without superview!")
+            print("[NEON] Warning: Attempted to group subviews but view doesn't have a superview of its own.")
             return
         }
 
@@ -1413,7 +1413,7 @@ extension UIView {
 
     private func groupInCornerVertical(views: [UIView], inCorner corner: Corner, padding: CGFloat, width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-            print("[NEON] Warning: Can't anchor view without superview!")
+            print("[NEON] Warning: Attempted to group subviews but view doesn't have a superview of its own.")
             return
         }
 
@@ -1461,7 +1461,7 @@ extension UIView {
 
     private func groupAndAlignHorizontal(align: Align, views: [UIView], relativeTo sibling: UIView, padding: CGFloat, width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-            print("[NEON] Warning: Can't anchor view without superview!")
+            print("[NEON] Warning: Attempted to group subviews but view doesn't have a superview of its own.")
             return
         }
 
@@ -1552,7 +1552,7 @@ extension UIView {
 
     private func groupAndAlignVertical(align: Align, views: [UIView], relativeTo sibling: UIView, padding: CGFloat, width: CGFloat, height: CGFloat) {
         guard let superview = superview else {
-            print("[NEON] Warning: Can't anchor view without superview!")
+            print("[NEON] Warning: Attempted to group subviews but view doesn't have a superview of its own.")
             return
         }
 


### PR DESCRIPTION
All nil checks on the superviews are now using guards. This makes sure you never have to force unwrap the variable.