### PR TITLE
Allow specifying xPad, yPad individually (ref #19)

### DIFF
--- a/NeonUnitTests/NeonUnitTests.swift
+++ b/NeonUnitTests/NeonUnitTests.swift
@@ -299,22 +299,22 @@ class NeonTests: XCTestCase {
     func testGroupInCornerHorizontal() {
         testAnchorView.anchorInCorner(.TopLeft, xPad: 0, yPad: 0, width: 500, height: 500)
 
-        testAnchorView.groupInCorner(group: .Horizontal, views: [testSiblingView2, testSiblingView3, testSiblingView4], inCorner: .TopLeft, padding: 10, width: 30, height: 30)
+        testAnchorView.groupInCorner(group: .Horizontal, views: [testSiblingView2, testSiblingView3, testSiblingView4], inCorner: .TopLeft, xPad: 10, yPad: 10, width: 30, height: 30)
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(10, 10, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(50, 10, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(90, 10, 30, 30)))
 
-        testAnchorView.groupInCorner(group: .Horizontal, views: [testSiblingView2, testSiblingView3, testSiblingView4], inCorner: .TopRight, padding: 10, width: 30, height: 30)
+        testAnchorView.groupInCorner(group: .Horizontal, views: [testSiblingView2, testSiblingView3, testSiblingView4], inCorner: .TopRight, xPad: 10, yPad: 10, width: 30, height: 30)
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(380, 10, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(420, 10, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(460, 10, 30, 30)))
 
-        testAnchorView.groupInCorner(group: .Horizontal, views: [testSiblingView2, testSiblingView3, testSiblingView4], inCorner: .BottomLeft, padding: 10, width: 30, height: 30)
+        testAnchorView.groupInCorner(group: .Horizontal, views: [testSiblingView2, testSiblingView3, testSiblingView4], inCorner: .BottomLeft, xPad: 10, yPad: 10, width: 30, height: 30)
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(10, 460, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(50, 460, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(90, 460, 30, 30)))
 
-        testAnchorView.groupInCorner(group: .Horizontal, views: [testSiblingView2, testSiblingView3, testSiblingView4], inCorner: .BottomRight, padding: 10, width: 30, height: 30)
+        testAnchorView.groupInCorner(group: .Horizontal, views: [testSiblingView2, testSiblingView3, testSiblingView4], inCorner: .BottomRight, xPad: 10, yPad: 10, width: 30, height: 30)
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(380, 460, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(420, 460, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(460, 460, 30, 30)))
@@ -323,22 +323,22 @@ class NeonTests: XCTestCase {
     func testGroupInCornerVertical() {
         testAnchorView.anchorInCorner(.TopLeft, xPad: 0, yPad: 0, width: 500, height: 500)
 
-        testAnchorView.groupInCorner(group: .Vertical, views: [testSiblingView2, testSiblingView3, testSiblingView4], inCorner: .TopLeft, padding: 10, width: 30, height: 30)
+        testAnchorView.groupInCorner(group: .Vertical, views: [testSiblingView2, testSiblingView3, testSiblingView4], inCorner: .TopLeft, xPad: 10, yPad: 10, width: 30, height: 30)
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(10, 10, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(10, 50, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(10, 90, 30, 30)))
 
-        testAnchorView.groupInCorner(group: .Vertical, views: [testSiblingView2, testSiblingView3, testSiblingView4], inCorner: .TopRight, padding: 10, width: 30, height: 30)
+        testAnchorView.groupInCorner(group: .Vertical, views: [testSiblingView2, testSiblingView3, testSiblingView4], inCorner: .TopRight, xPad: 10, yPad: 10, width: 30, height: 30)
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(460, 10, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(460, 50, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(460, 90, 30, 30)))
 
-        testAnchorView.groupInCorner(group: .Vertical, views: [testSiblingView2, testSiblingView3, testSiblingView4], inCorner: .BottomLeft, padding: 10, width: 30, height: 30)
+        testAnchorView.groupInCorner(group: .Vertical, views: [testSiblingView2, testSiblingView3, testSiblingView4], inCorner: .BottomLeft, xPad: 10, yPad: 10, width: 30, height: 30)
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(10, 380, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(10, 420, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(10, 460, 30, 30)))
 
-        testAnchorView.groupInCorner(group: .Vertical, views: [testSiblingView2, testSiblingView3, testSiblingView4], inCorner: .BottomRight, padding: 10, width: 30, height: 30)
+        testAnchorView.groupInCorner(group: .Vertical, views: [testSiblingView2, testSiblingView3, testSiblingView4], inCorner: .BottomRight, xPad: 10, yPad: 10, width: 30, height: 30)
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(460, 380, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(460, 420, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(460, 460, 30, 30)))
@@ -347,22 +347,22 @@ class NeonTests: XCTestCase {
     func testGroupAgainstEdgeHorizontal() {
         testAnchorView.anchorInCorner(.TopLeft, xPad: 0, yPad: 0, width: 500, height: 500)
 
-        testAnchorView.groupAgainstEdge(group: .Horizontal, views: [testSiblingView2, testSiblingView3, testSiblingView4], againstEdge: .Top, padding: 5, width: 40, height: 40)
+        testAnchorView.groupAgainstEdge(group: .Horizontal, views: [testSiblingView2, testSiblingView3, testSiblingView4], againstEdge: .Top, xPad: 5, yPad: 5, width: 40, height: 40)
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(185, 5, 40, 40)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(230, 5, 40, 40)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(275, 5, 40, 40)))
 
-        testAnchorView.groupAgainstEdge(group: .Horizontal, views: [testSiblingView2, testSiblingView3, testSiblingView4], againstEdge: .Left, padding: 5, width: 40, height: 40)
+        testAnchorView.groupAgainstEdge(group: .Horizontal, views: [testSiblingView2, testSiblingView3, testSiblingView4], againstEdge: .Left, xPad: 5, yPad: 5, width: 40, height: 40)
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(5, 230, 40, 40)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(50, 230, 40, 40)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(95, 230, 40, 40)))
 
-        testAnchorView.groupAgainstEdge(group: .Horizontal, views: [testSiblingView2, testSiblingView3, testSiblingView4], againstEdge: .Bottom, padding: 5, width: 40, height: 40)
+        testAnchorView.groupAgainstEdge(group: .Horizontal, views: [testSiblingView2, testSiblingView3, testSiblingView4], againstEdge: .Bottom, xPad: 5, yPad: 5, width: 40, height: 40)
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(185, 455, 40, 40)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(230, 455, 40, 40)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(275, 455, 40, 40)))
 
-        testAnchorView.groupAgainstEdge(group: .Horizontal, views: [testSiblingView2, testSiblingView3, testSiblingView4], againstEdge: .Right, padding: 5, width: 40, height: 40)
+        testAnchorView.groupAgainstEdge(group: .Horizontal, views: [testSiblingView2, testSiblingView3, testSiblingView4], againstEdge: .Right, xPad: 5, yPad: 5, width: 40, height: 40)
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(365, 230, 40, 40)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(410, 230, 40, 40)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(455, 230, 40, 40)))
@@ -371,22 +371,22 @@ class NeonTests: XCTestCase {
     func testGroupAgainstEdgeVertical() {
         testAnchorView.anchorInCorner(.TopLeft, xPad: 0, yPad: 0, width: 500, height: 500)
         
-        testAnchorView.groupAgainstEdge(group: .Vertical, views: [testSiblingView2, testSiblingView3, testSiblingView4], againstEdge: .Top, padding: 10, width: 60, height: 60)
+        testAnchorView.groupAgainstEdge(group: .Vertical, views: [testSiblingView2, testSiblingView3, testSiblingView4], againstEdge: .Top, xPad: 10, yPad: 10, width: 60, height: 60)
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(220, 10, 60, 60)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(220, 80, 60, 60)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(220, 150, 60, 60)))
         
-        testAnchorView.groupAgainstEdge(group: .Vertical, views: [testSiblingView2, testSiblingView3, testSiblingView4], againstEdge: .Left, padding: 10, width: 60, height: 60)
+        testAnchorView.groupAgainstEdge(group: .Vertical, views: [testSiblingView2, testSiblingView3, testSiblingView4], againstEdge: .Left, xPad: 10, yPad: 10, width: 60, height: 60)
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(10, 150, 60, 60)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(10, 220, 60, 60)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(10, 290, 60, 60)))
         
-        testAnchorView.groupAgainstEdge(group: .Vertical, views: [testSiblingView2, testSiblingView3, testSiblingView4], againstEdge: .Bottom, padding: 10, width: 60, height: 60)
+        testAnchorView.groupAgainstEdge(group: .Vertical, views: [testSiblingView2, testSiblingView3, testSiblingView4], againstEdge: .Bottom, xPad: 10, yPad: 10, width: 60, height: 60)
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(220, 290, 60, 60)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(220, 360, 60, 60)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(220, 430, 60, 60)))
         
-        testAnchorView.groupAgainstEdge(group: .Vertical, views: [testSiblingView2, testSiblingView3, testSiblingView4], againstEdge: .Right, padding: 10, width: 60, height: 60)
+        testAnchorView.groupAgainstEdge(group: .Vertical, views: [testSiblingView2, testSiblingView3, testSiblingView4], againstEdge: .Right, xPad: 10, yPad: 10, width: 60, height: 60)
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(430, 150, 60, 60)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(430, 220, 60, 60)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(430, 290, 60, 60)))
@@ -397,66 +397,66 @@ class NeonTests: XCTestCase {
         testSuperview.addSubview(testSiblingView2)
         testSuperview.addSubview(testSiblingView3)
 
-        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .ToTheRightMatchingTop, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .ToTheRightMatchingTop, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(105, 0, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(130, 0, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(155, 0, 20, 20)))
 
-        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .ToTheRightCentered, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .ToTheRightCentered, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(105, 40, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(130, 40, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(155, 40, 20, 20)))
 
-        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .ToTheRightMatchingBottom, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .ToTheRightMatchingBottom, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(105, 80, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(130, 80, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(155, 80, 20, 20)))
 
-        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .UnderMatchingLeft, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .UnderMatchingLeft, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(0, 105, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(25, 105, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(50, 105, 20, 20)))
 
-        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .UnderCentered, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .UnderCentered, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(15, 105, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(40, 105, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(65, 105, 20, 20)))
 
-        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .UnderMatchingRight, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .UnderMatchingRight, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(30, 105, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(55, 105, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(80, 105, 20, 20)))
 
         testAnchorView.anchorInCorner(.TopRight, xPad: 0, yPad: 0, width: 100, height: 100)
 
-        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .ToTheLeftMatchingTop, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .ToTheLeftMatchingTop, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(825, 0, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(850, 0, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(875, 0, 20, 20)))
 
-        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .ToTheLeftCentered, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .ToTheLeftCentered, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(825, 40, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(850, 40, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(875, 40, 20, 20)))
 
-        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .ToTheLeftMatchingBottom, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .ToTheLeftMatchingBottom, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(825, 80, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(850, 80, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(875, 80, 20, 20)))
 
         testAnchorView.anchorInCorner(.BottomLeft, xPad: 0, yPad: 0, width: 100, height: 100)
 
-        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .AboveMatchingLeft, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 30, height: 30)
+        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .AboveMatchingLeft, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 30, height: 30)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(0, 865, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(35, 865, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(70, 865, 30, 30)))
 
-        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .AboveCentered, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 30, height: 30)
+        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .AboveCentered, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 30, height: 30)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(0, 865, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(35, 865, 30, 30)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(70, 865, 30, 30)))
 
-        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .AboveMatchingRight, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Horizontal, andAlign: .AboveMatchingRight, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(30, 875, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(55, 875, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(80, 875, 20, 20)))
@@ -467,41 +467,41 @@ class NeonTests: XCTestCase {
         testSuperview.addSubview(testSiblingView2)
         testSuperview.addSubview(testSiblingView3)
 
-        testSuperview.groupAndAlign(group: .Vertical, andAlign: .ToTheRightMatchingTop, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Vertical, andAlign: .ToTheRightMatchingTop, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(105, 0, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(105, 25, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(105, 50, 20, 20)))
 
-        testSuperview.groupAndAlign(group: .Vertical, andAlign: .ToTheRightCentered, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Vertical, andAlign: .ToTheRightCentered, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(105, 15, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(105, 40, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(105, 65, 20, 20)))
 
-        testSuperview.groupAndAlign(group: .Vertical, andAlign: .ToTheRightMatchingBottom, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Vertical, andAlign: .ToTheRightMatchingBottom, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(105, 30, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(105, 55, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(105, 80, 20, 20)))
 
         testAnchorView.anchorInCorner(.TopRight, xPad: 0, yPad: 0, width: 100, height: 100)
 
-        testSuperview.groupAndAlign(group: .Vertical, andAlign: .ToTheLeftMatchingTop, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Vertical, andAlign: .ToTheLeftMatchingTop, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(875, 0, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(875, 25, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(875, 50, 20, 20)))
 
-        testSuperview.groupAndAlign(group: .Vertical, andAlign: .ToTheLeftCentered, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Vertical, andAlign: .ToTheLeftCentered, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(875, 15, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(875, 40, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(875, 65, 20, 20)))
 
-        testSuperview.groupAndAlign(group: .Vertical, andAlign: .ToTheLeftMatchingBottom, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Vertical, andAlign: .ToTheLeftMatchingBottom, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(875, 30, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(875, 55, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(875, 80, 20, 20)))
 
         testAnchorView.anchorInCorner(.TopLeft, xPad: 0, yPad: 0, width: 100, height: 100)
 
-        testSuperview.groupAndAlign(group: .Vertical, andAlign: .UnderMatchingLeft, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Vertical, andAlign: .UnderMatchingLeft, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(0, 105, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(0, 130, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(0, 155, 20, 20)))
@@ -511,24 +511,24 @@ class NeonTests: XCTestCase {
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(40, 130, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(40, 155, 20, 20)))
 
-        testSuperview.groupAndAlign(group: .Vertical, andAlign: .UnderMatchingRight, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Vertical, andAlign: .UnderMatchingRight, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(80, 105, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(80, 130, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(80, 155, 20, 20)))
 
         testAnchorView.anchorInCorner(.BottomLeft, xPad: 0, yPad: 0, width: 100, height: 100)
 
-        testSuperview.groupAndAlign(group: .Vertical, andAlign: .AboveMatchingLeft, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Vertical, andAlign: .AboveMatchingLeft, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(0, 825, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(0, 850, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(0, 875, 20, 20)))
 
-        testSuperview.groupAndAlign(group: .Vertical, andAlign: .AboveCentered, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Vertical, andAlign: .AboveCentered, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(40, 825, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(40, 850, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(40, 875, 20, 20)))
 
-        testSuperview.groupAndAlign(group: .Vertical, andAlign: .AboveMatchingRight, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, padding: 5, width: 20, height: 20)
+        testSuperview.groupAndAlign(group: .Vertical, andAlign: .AboveMatchingRight, views: [testSiblingView, testSiblingView2, testSiblingView3], relativeTo: testAnchorView, xPad: 5, yPad: 5, width: 20, height: 20)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(80, 825, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(80, 850, 20, 20)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(80, 875, 20, 20)))
@@ -539,23 +539,23 @@ class NeonTests: XCTestCase {
         testSuperview.addSubview(testSiblingView3)
         testSuperview.addSubview(testSiblingView4)
 
-        testSuperview.groupAndFill(group: .Horizontal, views: [testSiblingView, testSiblingView2, testSiblingView3], padding: 10)
+        testSuperview.groupAndFill(group: .Horizontal, views: [testSiblingView, testSiblingView2, testSiblingView3], xPad: 10, yPad: 10)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(10, 10, 320, 980)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(340, 10, 320, 980)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(670, 10, 320, 980)))
 
-        testSuperview.groupAndFill(group: .Horizontal, views: [testSiblingView, testSiblingView2, testSiblingView3, testSiblingView4], padding: 2)
+        testSuperview.groupAndFill(group: .Horizontal, views: [testSiblingView, testSiblingView2, testSiblingView3, testSiblingView4], xPad: 2, yPad: 2)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(2, 2, 247.5, 996)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(251.5, 2, 247.5, 996)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(501, 2, 247.5, 996)))
         XCTAssert(CGRectEqualToRect(testSiblingView4.frame, CGRectMake(750.5, 2, 247.5, 996)))
 
-        testSuperview.groupAndFill(group: .Vertical, views: [testSiblingView, testSiblingView2, testSiblingView3], padding: 10)
+        testSuperview.groupAndFill(group: .Vertical, views: [testSiblingView, testSiblingView2, testSiblingView3], xPad: 10, yPad: 10)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(10, 10, 980, 320)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(10, 340, 980, 320)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(10, 670, 980, 320)))
 
-        testSuperview.groupAndFill(group: .Vertical, views: [testSiblingView, testSiblingView2, testSiblingView3, testSiblingView4], padding: 2)
+        testSuperview.groupAndFill(group: .Vertical, views: [testSiblingView, testSiblingView2, testSiblingView3, testSiblingView4], xPad: 2, yPad: 2)
         XCTAssert(CGRectEqualToRect(testSiblingView.frame, CGRectMake(2, 2, 996, 247.5)))
         XCTAssert(CGRectEqualToRect(testSiblingView2.frame, CGRectMake(2, 251.5, 996, 247.5)))
         XCTAssert(CGRectEqualToRect(testSiblingView3.frame, CGRectMake(2, 501, 996, 247.5)))

--- a/Source/NeonGroupable.swift
+++ b/Source/NeonGroupable.swift
@@ -75,105 +75,112 @@ public extension Groupable {
     ///
     ///   - inCorner: The specified corner the views will be grouped in.
     ///
-    ///   - padding: The padding to be applied between the subviews and their superview.
+   	///   - xPad: If the `Group` type is horizontal, this is the padding to be applied between each of the subviews. Otherwise,
+	/// this is the padding between this group and its' superview.
+	/// 
+	///   - yPad: If the `Group` type is horizontal, this is the padding to be applied between this group and its' superview.
+	/// Otherwise, this is the padding to be applied between each of the subviews.
     ///
     ///   - width: The width of each subview.
     ///
     ///   - height: The height of each subview.
     ///
-    public func groupInCorner(group group: Group, views: [Frameable], inCorner corner: Corner, padding: CGFloat, width: CGFloat, height: CGFloat) {
+    public func groupInCorner(group group: Group, views: [Frameable], inCorner corner: Corner, xPad: CGFloat, yPad: CGFloat, width: CGFloat, height: CGFloat) {
         switch group {
         case .Horizontal:
-            groupInCornerHorizontal(views, inCorner: corner, padding: padding, width: width, height: height)
+            groupInCornerHorizontal(views, inCorner: corner, xPad: xPad, yPad: yPad, width: width, height: height)
 
         case .Vertical:
-            groupInCornerVertical(views, inCorner: corner, padding: padding, width: width, height: height)
+            groupInCornerVertical(views, inCorner: corner, xPad: xPad, yPad: yPad, width: width, height: height)
         }
     }
 
+	/// Tell a view to group an array of its subviews against one of its edges, specifying the padding between each subview
+	/// and their superview, as well as the size of each.
+	///
+	/// - parameters:
+	///   - group: The `Group` type specifying if the subviews will be laid out horizontally or vertically against the specified
+	/// edge.
+	///
+	///   - views: The array of views to grouped against the spcified edge. Depending on if the views are gouped horizontally
+	/// or vertically, they will be positioned in-order from left-to-right and top-to-bottom, respectively.
+	///
+	///   - againstEdge: The specified edge the views will be grouped against.
+	///
+	///   - xPad: If the `Group` type is horizontal, this is the padding to be applied between each of the subviews. Otherwise,
+	/// this is the padding between this group and its' superview.
+	/// 
+	///   - yPad: If the `Group` type is horizontal, this is the padding to be applied between this group and its' superview.
+	/// Otherwise, this is the padding to be applied between each of the subviews.
+	///
+	///   - width: The width of each subview.
+	///
+	///   - height: The height of each subview.
+	///
+	public func groupAgainstEdge(group group: Group, views: [Frameable], againstEdge edge: Edge, xPad: CGFloat, yPad: CGFloat, width: CGFloat, height: CGFloat) {
+		if views.count == 0 {
+			print("[NEON] Warning: No subviews provided to groupAgainstEdge().")
+			return
+		}
 
-    /// Tell a view to group an array of its subviews against one of its edges, specifying the padding between each subview
-    /// and their superview, as well as the size of each.
-    ///
-    /// - parameters:
-    ///   - group: The `Group` type specifying if the subviews will be laid out horizontally or vertically against the specified
-    /// edge.
-    ///
-    ///   - views: The array of views to grouped against the spcified edge. Depending on if the views are gouped horizontally
-    /// or vertically, they will be positioned in-order from left-to-right and top-to-bottom, respectively.
-    ///
-    ///   - againstEdge: The specified edge the views will be grouped against.
-    ///
-    ///   - padding: The padding to be applied between each of the subviews and their superview.
-    ///
-    ///   - width: The width of each subview.
-    ///
-    ///   - height: The height of each subview.
-    ///
-    public func groupAgainstEdge(group group: Group, views: [Frameable], againstEdge edge: Edge, padding: CGFloat, width: CGFloat, height: CGFloat) {
-        if views.count == 0 {
-            print("[NEON] Warning: No subviews provided to groupAgainstEdge().")
-            return
-        }
+		var xOrigin : CGFloat = 0.0
+		var yOrigin : CGFloat = 0.0
+		var xAdjust : CGFloat = 0.0
+		var yAdjust : CGFloat = 0.0
 
-        var xOrigin : CGFloat = 0.0
-        var yOrigin : CGFloat = 0.0
-        var xAdjust : CGFloat = 0.0
-        var yAdjust : CGFloat = 0.0
+		switch edge {
+		case .Top:
+			if group == .Horizontal {
+				xOrigin = (self.width - (CGFloat(views.count) * width) - (CGFloat(views.count - 1) * xPad)) / 2.0
+				xAdjust = width + xPad
+			} else {
+				xOrigin = (self.width / 2.0) - (width / 2.0)
+				yAdjust = height + yPad
+			}
 
-        switch edge {
-        case .Top:
-            if group == .Horizontal {
-                xOrigin = (self.width - (CGFloat(views.count) * width) - (CGFloat(views.count - 1) * padding)) / 2.0
-                xAdjust = width + padding
-            } else {
-                xOrigin = (self.width / 2.0) - (width / 2.0)
-                yAdjust = height + padding
-            }
+			yOrigin = yPad
 
-            yOrigin = padding
+		case .Left:
+			if group == .Horizontal {
+				yOrigin = (self.height / 2.0) - (height / 2.0)
+				xAdjust = width + xPad
+			} else {
+				yOrigin = (self.height - (CGFloat(views.count) * height) - (CGFloat(views.count - 1) * yPad)) / 2.0
+				yAdjust = height + yPad
+			}
 
-        case .Left:
-            if group == .Horizontal {
-                yOrigin = (self.height / 2.0) - (height / 2.0)
-                xAdjust = width + padding
-            } else {
-                yOrigin = (self.height - (CGFloat(views.count) * height) - (CGFloat(views.count - 1) * padding)) / 2.0
-                yAdjust = height + padding
-            }
+			xOrigin = xPad
 
-            xOrigin = padding
+		case .Bottom:
+			if group == .Horizontal {
+				xOrigin = (self.width - (CGFloat(views.count) * width) - (CGFloat(views.count - 1) * xPad)) / 2.0
+				yOrigin = self.height - height - yPad
+				xAdjust = width + xPad
+			} else {
+				xOrigin = (self.width / 2.0) - (width / 2.0)
+				yOrigin = self.height - (CGFloat(views.count) * height) - (CGFloat(views.count) * yPad)
+				yAdjust = height + yPad
+			}
 
-        case .Bottom:
-            if group == .Horizontal {
-                xOrigin = (self.width - (CGFloat(views.count) * width) - (CGFloat(views.count - 1) * padding)) / 2.0
-                yOrigin = self.height - height - padding
-                xAdjust = width + padding
-            } else {
-                xOrigin = (self.width / 2.0) - (width / 2.0)
-                yOrigin = self.height - (CGFloat(views.count) * height) - (CGFloat(views.count) * padding)
-                yAdjust = height + padding
-            }
+		case .Right:
+			if group == .Horizontal {
+				xOrigin = self.width - (CGFloat(views.count) * width) - (CGFloat(views.count) * xPad)
+				yOrigin = (self.height / 2.0) - (height / 2.0)
+				xAdjust = width + xPad
+			} else {
+				xOrigin = self.width - width - xPad
+				yOrigin = (self.height - (CGFloat(views.count) * height) - (CGFloat(views.count - 1) * yPad)) / 2.0
+				yAdjust = height + yPad
+			}
+		}
 
-        case .Right:
-            if group == .Horizontal {
-                xOrigin = self.width - (CGFloat(views.count) * width) - (CGFloat(views.count) * padding)
-                yOrigin = (self.height / 2.0) - (height / 2.0)
-                xAdjust = width + padding
-            } else {
-                xOrigin = self.width - width - padding
-                yOrigin = (self.height - (CGFloat(views.count) * height) - (CGFloat(views.count - 1) * padding)) / 2.0
-                yAdjust = height + padding
-            }
-        }
+		for view in views {
+			view.frame = CGRectMake(xOrigin, yOrigin, width, height)
 
-        for view in views {
-            view.frame = CGRectMake(xOrigin, yOrigin, width, height)
-
-            xOrigin += xAdjust
-            yOrigin += yAdjust
-        }
-    }
+			xOrigin += xAdjust
+			yOrigin += yAdjust
+		}
+	}
 
 
     /// Tell a view to group an array of its subviews relative to another of that view's subview, specifying the padding between
@@ -190,72 +197,80 @@ public extension Groupable {
     ///
     ///   - relativeTo: The sibling view that the views will be aligned relative to.
     ///
-    ///   - padding: The padding to be applied between each of the subviews and the sibling.
+	///   - xPad: If the `Group` type is horizontal, this is the padding to be applied between each of the subviews. Otherwise,
+	/// this is the padding between this group and its' sibling.
+	/// 
+	///   - yPad: If the `Group` type is horizontal, this is the padding to be applied between this group and its' sibling.
+	/// Otherwise, this is the padding to be applied between each of the subviews.
     ///
     ///   - width: The width of each subview.
     ///
     ///   - height: The height of each subview.
     ///
-    public func groupAndAlign(group group: Group, andAlign align: Align, views: [Frameable], relativeTo sibling: Frameable, padding: CGFloat, width: CGFloat, height: CGFloat) {
+    public func groupAndAlign(group group: Group, andAlign align: Align, views: [Frameable], relativeTo sibling: Frameable, xPad: CGFloat, yPad: CGFloat, width: CGFloat, height: CGFloat) {
         switch group {
         case .Horizontal:
-            groupAndAlignHorizontal(align, views: views, relativeTo: sibling, padding: padding, width: width, height: height)
+            groupAndAlignHorizontal(align, views: views, relativeTo: sibling, xPad: xPad, yPad: yPad, width: width, height: height)
 
         case .Vertical:
-            groupAndAlignVertical(align, views: views, relativeTo: sibling, padding: padding, width: width, height: height)
+            groupAndAlignVertical(align, views: views, relativeTo: sibling, xPad: xPad, yPad: yPad, width: width, height: height)
         }
     }
 
 
-    /// Tell a view to group an array of its subviews filling the width and height of the superview, specifying the padding between
-    /// each subview and the superview.
-    ///
-    /// - parameters:
-    ///   - group: The `Group` type specifying if the subviews will be laid out horizontally or vertically.
-    ///
-    ///   - views: The array of views to be grouped against the sibling. Depending on if the views are grouped horizontally
-    /// or vertically, they will be positions in-order from left-to-right and top-to-bottom, respectively.
-    ///
-    ///   - padding: The padding to be applied between each of the subviews and the sibling.
-    ///
-    public func groupAndFill(group group: Group, views: [Frameable], padding: CGFloat) {
-        if views.count == 0 {
-            print("[NEON] Warning: No subviews provided to groupAndFill().")
-            return
-        }
+	/// Tell a view to group an array of its subviews filling the width and height of the superview, specifying the padding between
+	/// each subview and the superview.
+	///
+	/// - parameters:
+	///   - group: The `Group` type specifying if the subviews will be laid out horizontally or vertically.
+	///
+	///   - views: The array of views to be grouped against the sibling. Depending on if the views are grouped horizontally
+	/// or vertically, they will be positions in-order from left-to-right and top-to-bottom, respectively.
+	///
+	///   - xPad: If the `Group` type is horizontal, this is the padding to be applied between each of the subviews. Otherwise,
+	/// this is the padding between this group and its' superview.
+	///
+	///   - yPad: If the `Group` type is horizontal, this is the padding to be applied between this group and its' superview.
+	/// Otherwise, this is the padding to be applied between each of the subviews.
+	///
+	public func groupAndFill(group group: Group, views: [Frameable], xPad: CGFloat, yPad: CGFloat) {
+		if views.count == 0 {
+			print("[NEON] Warning: No subviews provided to groupAndFill().")
+			return
+		}
 
-        var xOrigin : CGFloat = padding
-        var yOrigin : CGFloat = padding
-        var width : CGFloat = 0.0
-        var height : CGFloat = 0.0
-        var xAdjust : CGFloat = 0.0
-        var yAdjust : CGFloat = 0.0
+		var xOrigin : CGFloat = xPad
+		var yOrigin : CGFloat = yPad
+		var width : CGFloat = 0.0
+		var height : CGFloat = 0.0
+		var xAdjust : CGFloat = 0.0
+		var yAdjust : CGFloat = 0.0
 
-        switch group {
-        case .Horizontal:
-            width = (self.width - (CGFloat(views.count + 1) * padding)) / CGFloat(views.count)
-            height = self.height - (2 * padding)
-            xAdjust = width + padding
+		switch group {
+		case .Horizontal:
+			width = (self.width - (CGFloat(views.count + 1) * xPad)) / CGFloat(views.count)
+			height = self.height - (2 * yPad)
+			xAdjust = width + xPad
 
-        case .Vertical:
-            width = self.width - (2 * padding)
-            height = (self.height - (CGFloat(views.count + 1) * padding)) / CGFloat(views.count)
-            yAdjust = height + padding
-        }
+		case .Vertical:
+			width = self.width - (2 * xPad)
+			height = (self.height - (CGFloat(views.count + 1) * yPad)) / CGFloat(views.count)
+			yAdjust = height + yPad
+		}
 
-        for view in views {
-            view.frame = CGRectMake(xOrigin, yOrigin, width, height)
+		for view in views {
+			view.frame = CGRectMake(xOrigin, yOrigin, width, height)
 
-            xOrigin += xAdjust
-            yOrigin += yAdjust
-        }
-    }
+			xOrigin += xAdjust
+			yOrigin += yAdjust
+		}
+	}
 
 
 
     // MARK: Private utils
     //
-    private func groupInCornerHorizontal(views: [Frameable], inCorner corner: Corner, padding: CGFloat, width: CGFloat, height: CGFloat) {
+    private func groupInCornerHorizontal(views: [Frameable], inCorner corner: Corner, xPad: CGFloat, yPad: CGFloat, width: CGFloat, height: CGFloat) {
         if views.count == 0 {
             print("[NEON] Warning: No subviews provided to groupInCorner().")
             return
@@ -263,24 +278,24 @@ public extension Groupable {
 
         var xOrigin : CGFloat = 0.0
         var yOrigin : CGFloat = 0.0
-        let xAdjust : CGFloat = width + padding
+        let xAdjust : CGFloat = width + xPad
 
         switch corner {
         case .TopLeft:
-            xOrigin = padding
-            yOrigin = padding
+            xOrigin = xPad
+            yOrigin = yPad
 
         case .TopRight:
-            xOrigin = self.width - ((CGFloat(views.count) * width) + (CGFloat(views.count) * padding))
-            yOrigin = padding
+            xOrigin = self.width - ((CGFloat(views.count) * width) + (CGFloat(views.count) * xPad))
+            yOrigin = yPad
 
         case .BottomLeft:
-            xOrigin = padding
-            yOrigin = self.height - height - padding
+            xOrigin = xPad
+            yOrigin = self.height - height - yPad
 
         case .BottomRight:
-            xOrigin = self.width - ((CGFloat(views.count) * width) + (CGFloat(views.count) * padding))
-            yOrigin = self.height - height - padding
+            xOrigin = self.width - ((CGFloat(views.count) * width) + (CGFloat(views.count) * xPad))
+            yOrigin = self.height - height - yPad
         }
 
         for view in views {
@@ -290,7 +305,7 @@ public extension Groupable {
         }
     }
 
-    private func groupInCornerVertical(views: [Frameable], inCorner corner: Corner, padding: CGFloat, width: CGFloat, height: CGFloat) {
+    private func groupInCornerVertical(views: [Frameable], inCorner corner: Corner, xPad: CGFloat, yPad: CGFloat, width: CGFloat, height: CGFloat) {
         if views.count == 0 {
             print("[NEON] Warning: No subviews provided to groupInCorner().")
             return
@@ -298,24 +313,24 @@ public extension Groupable {
 
         var xOrigin : CGFloat = 0.0
         var yOrigin : CGFloat = 0.0
-        let yAdjust : CGFloat = height + padding
+        let yAdjust : CGFloat = height + yPad
 
         switch corner {
         case .TopLeft:
-            xOrigin = padding
-            yOrigin = padding
+            xOrigin = xPad
+            yOrigin = yPad
 
         case .TopRight:
-            xOrigin = self.width - width - padding
-            yOrigin = padding
+            xOrigin = self.width - width - xPad
+            yOrigin = yPad
 
         case .BottomLeft:
-            xOrigin = padding
-            yOrigin = self.height - ((CGFloat(views.count) * height) + (CGFloat(views.count) * padding))
+            xOrigin = xPad
+            yOrigin = self.height - ((CGFloat(views.count) * height) + (CGFloat(views.count) * yPad))
 
         case .BottomRight:
-            xOrigin = self.width - width - padding
-            yOrigin = self.height - ((CGFloat(views.count) * height) + (CGFloat(views.count) * padding))
+            xOrigin = self.width - width - xPad
+            yOrigin = self.height - ((CGFloat(views.count) * height) + (CGFloat(views.count) * yPad))
         }
 
         for view in views {
@@ -325,7 +340,7 @@ public extension Groupable {
         }
     }
 
-    private func groupAndAlignHorizontal(align: Align, views: [Frameable], relativeTo sibling: Frameable, padding: CGFloat, width: CGFloat, height: CGFloat) {
+    private func groupAndAlignHorizontal(align: Align, views: [Frameable], relativeTo sibling: Frameable, xPad: CGFloat, yPad: CGFloat, width: CGFloat, height: CGFloat) {
         if views.count == 0 {
             print("[NEON] Warning: No subviews provided to groupAndAlign().")
             return
@@ -333,56 +348,56 @@ public extension Groupable {
 
         var xOrigin : CGFloat = 0.0
         var yOrigin : CGFloat = 0.0
-        let xAdjust : CGFloat = width + padding
+        let xAdjust : CGFloat = width + xPad
 
         switch align {
         case .ToTheRightMatchingTop:
-            xOrigin = sibling.xMax + padding
+            xOrigin = sibling.xMax + xPad
             yOrigin = sibling.y
 
         case .ToTheRightMatchingBottom:
-            xOrigin = sibling.xMax + padding
+            xOrigin = sibling.xMax + xPad
             yOrigin = sibling.yMax - height
 
         case .ToTheRightCentered:
-            xOrigin = sibling.xMax + padding
+            xOrigin = sibling.xMax + xPad
             yOrigin = sibling.yMid - (height / 2.0)
 
         case .ToTheLeftMatchingTop:
-            xOrigin = sibling.x - (CGFloat(views.count) * width) - (CGFloat(views.count) * padding)
+            xOrigin = sibling.x - (CGFloat(views.count) * width) - (CGFloat(views.count) * xPad)
             yOrigin = sibling.y
 
         case .ToTheLeftMatchingBottom:
-            xOrigin = sibling.x - (CGFloat(views.count) * width) - (CGFloat(views.count) * padding)
+            xOrigin = sibling.x - (CGFloat(views.count) * width) - (CGFloat(views.count) * xPad)
             yOrigin = sibling.yMax - height
 
         case .ToTheLeftCentered:
-            xOrigin = sibling.x - (CGFloat(views.count) * width) - (CGFloat(views.count) * padding)
+            xOrigin = sibling.x - (CGFloat(views.count) * width) - (CGFloat(views.count) * xPad)
             yOrigin = sibling.yMid - (height / 2.0)
 
         case .UnderMatchingLeft:
             xOrigin = sibling.x
-            yOrigin = sibling.yMax + padding
+            yOrigin = sibling.yMax + yPad
 
         case .UnderMatchingRight:
-            xOrigin = sibling.xMax - (CGFloat(views.count) * width) - (CGFloat(views.count - 1) * padding)
-            yOrigin = sibling.yMax + padding
+            xOrigin = sibling.xMax - (CGFloat(views.count) * width) - (CGFloat(views.count - 1) * xPad)
+            yOrigin = sibling.yMax + yPad
 
         case .UnderCentered:
-            xOrigin = sibling.xMid - ((CGFloat(views.count) * width) + (CGFloat(views.count - 1) * padding)) / 2.0
-            yOrigin = sibling.yMax + padding
+            xOrigin = sibling.xMid - ((CGFloat(views.count) * width) + (CGFloat(views.count - 1) * xPad)) / 2.0
+            yOrigin = sibling.yMax + yPad
 
         case .AboveMatchingLeft:
             xOrigin = sibling.x
-            yOrigin = sibling.y - height - padding
+            yOrigin = sibling.y - height - yPad
 
         case .AboveMatchingRight:
-            xOrigin = sibling.xMax - (CGFloat(views.count) * width) - (CGFloat(views.count - 1) * padding)
-            yOrigin = sibling.y - height - padding
+            xOrigin = sibling.xMax - (CGFloat(views.count) * width) - (CGFloat(views.count - 1) * xPad)
+            yOrigin = sibling.y - height - yPad
 
         case .AboveCentered:
-            xOrigin = sibling.xMid - ((CGFloat(views.count) * width) + (CGFloat(views.count - 1) * padding)) / 2.0
-            yOrigin = sibling.y - height - padding
+            xOrigin = sibling.xMid - ((CGFloat(views.count) * width) + (CGFloat(views.count - 1) * xPad)) / 2.0
+            yOrigin = sibling.y - height - yPad
         }
 
         for view in views {
@@ -392,7 +407,7 @@ public extension Groupable {
         }
     }
 
-    private func groupAndAlignVertical(align: Align, views: [Frameable], relativeTo sibling: Frameable, padding: CGFloat, width: CGFloat, height: CGFloat) {
+    private func groupAndAlignVertical(align: Align, views: [Frameable], relativeTo sibling: Frameable, xPad: CGFloat, yPad: CGFloat, width: CGFloat, height: CGFloat) {
         if views.count == 0 {
             print("[NEON] Warning: No subviews provided to groupAndAlign().")
             return
@@ -400,56 +415,56 @@ public extension Groupable {
 
         var xOrigin : CGFloat = 0.0
         var yOrigin : CGFloat = 0.0
-        let yAdjust : CGFloat = height + padding
+        let yAdjust : CGFloat = height + yPad
 
         switch align {
         case .ToTheRightMatchingTop:
-            xOrigin = sibling.xMax + padding
+            xOrigin = sibling.xMax + xPad
             yOrigin = sibling.y
 
         case .ToTheRightMatchingBottom:
-            xOrigin = sibling.xMax + padding
-            yOrigin = sibling.yMax - (CGFloat(views.count) * height) - (CGFloat(views.count - 1) * padding)
+            xOrigin = sibling.xMax + xPad
+            yOrigin = sibling.yMax - (CGFloat(views.count) * height) - (CGFloat(views.count - 1) * yPad)
 
         case .ToTheRightCentered:
-            xOrigin = sibling.xMax + padding
-            yOrigin = sibling.yMid - ((CGFloat(views.count) * height) + CGFloat(views.count - 1) * padding) / 2.0
+            xOrigin = sibling.xMax + xPad
+            yOrigin = sibling.yMid - ((CGFloat(views.count) * height) + CGFloat(views.count - 1) * yPad) / 2.0
 
         case .ToTheLeftMatchingTop:
-            xOrigin = sibling.x - width - padding
+            xOrigin = sibling.x - width - xPad
             yOrigin = sibling.y
 
         case .ToTheLeftMatchingBottom:
-            xOrigin = sibling.x - width - padding
-            yOrigin = sibling.yMax - (CGFloat(views.count) * height) - (CGFloat(views.count - 1) * padding)
+            xOrigin = sibling.x - width - xPad
+            yOrigin = sibling.yMax - (CGFloat(views.count) * height) - (CGFloat(views.count - 1) * yPad)
 
         case .ToTheLeftCentered:
-            xOrigin = sibling.x - width - padding
-            yOrigin = sibling.yMid - ((CGFloat(views.count) * height) + CGFloat(views.count - 1) * padding) / 2.0
+            xOrigin = sibling.x - width - xPad
+            yOrigin = sibling.yMid - ((CGFloat(views.count) * height) + CGFloat(views.count - 1) * yPad) / 2.0
 
         case .UnderMatchingLeft:
             xOrigin = sibling.x
-            yOrigin = sibling.yMax + padding
+            yOrigin = sibling.yMax + yPad
 
         case .UnderMatchingRight:
             xOrigin = sibling.xMax - width
-            yOrigin = sibling.yMax + padding
+            yOrigin = sibling.yMax + yPad
 
         case .UnderCentered:
             xOrigin = sibling.xMid - (width / 2.0)
-            yOrigin = sibling.yMax + padding
+            yOrigin = sibling.yMax + yPad
 
         case .AboveMatchingLeft:
             xOrigin = sibling.x
-            yOrigin = sibling.y - (CGFloat(views.count) * height) - (CGFloat(views.count) * padding)
+            yOrigin = sibling.y - (CGFloat(views.count) * height) - (CGFloat(views.count) * yPad)
             
         case .AboveMatchingRight:
             xOrigin = sibling.xMax - width
-            yOrigin = sibling.y - (CGFloat(views.count) * height) - (CGFloat(views.count) * padding)
+            yOrigin = sibling.y - (CGFloat(views.count) * height) - (CGFloat(views.count) * yPad)
             
         case .AboveCentered:
             xOrigin = sibling.xMid - (width / 2.0)
-            yOrigin = sibling.y - (CGFloat(views.count) * height) - (CGFloat(views.count) * padding)
+            yOrigin = sibling.y - (CGFloat(views.count) * height) - (CGFloat(views.count) * yPad)
         }
         
         for view in views {


### PR DESCRIPTION
This is my attempt at addressing the issue I raised in #19. Obviously we should add some tests for the case where xPad != yPad, but I wanted to get this out there quickly for discussion/feedback.