### PR TITLE
Align views next to each other to the write while wrapping

### DIFF
--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -34,6 +34,19 @@ class ViewController: UIViewController {
     let view19 : UILabel = UILabel()
     let view20 : UILabel = UILabel()
 
+    let labelA : UILabel = UILabel()
+    let labelB : UILabel = UILabel()
+    let labelC : UILabel = UILabel()
+    let labelD : UILabel = UILabel()
+
+    let labelE : UILabel = UILabel()
+    let labelF : UILabel = UILabel()
+    let labelG : UILabel = UILabel()
+    let labelH : UILabel = UILabel()
+
+    let labelI : UILabel = UILabel()
+    let labelJ : UILabel = UILabel()
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -183,6 +196,77 @@ class ViewController: UIViewController {
         view20.font = UIFont.boldSystemFontOfSize(20)
         view20.textColor = UIColor.whiteColor()
         containerView.addSubview(view20)
+
+        labelA.backgroundColor = UIColor(red: 255/255.0, green: 100/255.0, blue: 50/255.0, alpha: 1.0)
+        labelA.text = "AAAAA"
+        labelA.textAlignment = .Left
+        labelA.font = UIFont.boldSystemFontOfSize(14)
+        labelA.textColor = UIColor.whiteColor()
+        view20.addSubview(labelA)
+
+        labelB.backgroundColor = UIColor(red: 100/255.0, green: 50/255.0, blue: 255/255.0, alpha: 1.0)
+        labelB.text = "BBBBBBBBBBB"
+        labelB.textAlignment = .Left
+        labelB.font = UIFont.boldSystemFontOfSize(14)
+        labelB.textColor = UIColor.whiteColor()
+        view20.addSubview(labelB)
+
+        labelC.backgroundColor = UIColor(red: 50/255.0, green: 255/255.0, blue: 100/255.0, alpha: 1.0)
+        labelC.text = "CCCC"
+        labelC.textAlignment = .Left
+        labelC.font = UIFont.boldSystemFontOfSize(14)
+        labelC.textColor = UIColor.whiteColor()
+        view20.addSubview(labelC)
+
+        labelD.backgroundColor = UIColor(red: 100/255.0, green: 100/255.0, blue: 100/255.0, alpha: 1.0)
+        labelD.text = "DDDDDDDDDD"
+        labelD.textAlignment = .Left
+        labelD.font = UIFont.boldSystemFontOfSize(14)
+        labelD.textColor = UIColor.whiteColor()
+        view20.addSubview(labelD)
+
+        labelE.backgroundColor = UIColor(red: 255/255.0, green: 100/255.0, blue: 255/255.0, alpha: 1.0)
+        labelE.text = "EEEE"
+        labelE.textAlignment = .Left
+        labelE.font = UIFont.boldSystemFontOfSize(14)
+        labelE.textColor = UIColor.whiteColor()
+        view20.addSubview(labelE)
+
+        labelF.backgroundColor = UIColor(red: 100/255.0, green: 50/255.0, blue: 100/255.0, alpha: 1.0)
+        labelF.text = "FFFFFFFF"
+        labelF.textAlignment = .Left
+        labelF.font = UIFont.boldSystemFontOfSize(14)
+        labelF.textColor = UIColor.whiteColor()
+        view20.addSubview(labelF)
+
+        labelG.backgroundColor = UIColor(red: 200/255.0, green: 200/255.0, blue: 0/255.0, alpha: 1.0)
+        labelG.text = "GGGG"
+        labelG.textAlignment = .Left
+        labelG.font = UIFont.boldSystemFontOfSize(14)
+        labelG.textColor = UIColor.whiteColor()
+        view20.addSubview(labelG)
+
+        labelH.backgroundColor = UIColor(red: 150/255.0, green: 100/255.0, blue: 50/255.0, alpha: 1.0)
+        labelH.text = "HHHHHH"
+        labelH.textAlignment = .Left
+        labelH.font = UIFont.boldSystemFontOfSize(14)
+        labelH.textColor = UIColor.whiteColor()
+        view20.addSubview(labelH)
+
+        labelI.backgroundColor = UIColor(red: 150/255.0, green: 100/255.0, blue: 50/255.0, alpha: 1.0)
+        labelI.text = "IXIXIXIXIXI"
+        labelI.textAlignment = .Left
+        labelI.font = UIFont.boldSystemFontOfSize(14)
+        labelI.textColor = UIColor.whiteColor()
+        view20.addSubview(labelI)
+
+        labelJ.backgroundColor = UIColor(red: 255/255.0, green: 255/255.0, blue: 255/255.0, alpha: 1.0)
+        labelJ.text = "J"
+        labelJ.textAlignment = .Center
+        labelJ.font = UIFont.boldSystemFontOfSize(14)
+        labelJ.textColor = UIColor.blackColor()
+        view20.addSubview(labelJ)
+
     }
 
     override func viewWillLayoutSubviews() {
@@ -213,6 +297,21 @@ class ViewController: UIViewController {
         view18.alignBetweenVertical(align: .UnderMatchingLeft, primaryView: anchorView, secondaryView: view16, padding: 10, width: anchorView.width)
         view19.alignBetweenHorizontal(align: .ToTheRightMatchingTop, primaryView: view14, secondaryView: view18, padding: 10, height: 50)
         view20.alignBetweenVertical(align: .UnderCentered, primaryView: view17, secondaryView: view19, padding: 10, width: view17.width)
+
+        labelA.anchorInCorner(.TopLeft, xPad: 5, yPad: 5, width: AutoWidth, height: 20)
+        labelB.align(.ToTheRightMatchingTopWrapping, relativeTo: labelA, padding: 5, width: AutoWidth, height: 20)
+        labelC.align(.ToTheRightMatchingTopWrapping, relativeTo: labelB, padding: 5, width: AutoWidth, height: 20)
+        labelD.align(.ToTheRightMatchingTopWrapping, relativeTo: labelC, padding: 5, width: AutoWidth, height: 20)
+
+        labelE.align(.UnderMatchingLeftFollowing, relativeTo: labelD, padding: 5, width: AutoWidth, height: 20)
+        labelF.align(.ToTheRightMatchingTopWrapping, relativeTo: labelE, padding: 5, width: AutoWidth, height: 20)
+        labelG.align(.ToTheRightMatchingTopWrapping, relativeTo: labelF, padding: 5, width: AutoWidth, height: 20)
+        labelH.align(.ToTheRightMatchingTopWrapping, relativeTo: labelG, padding: 5, width: AutoWidth, height: 20)
+
+        labelI.alignAndFillWidth(align: .UnderMatchingLeftFollowing, relativeTo: labelH, padding:5, height:20)
+
+        labelJ.align(.UnderCentered, relativeTo: labelI, padding:20, width:50, height:50)
+
     }
 
     override func touchesMoved(touches: Set<UITouch>, withEvent event: UIEvent?) {

--- a/Source/Neon.swift
+++ b/Source/Neon.swift
@@ -23,7 +23,7 @@ extension View : Frameable, Anchorable, Alignable, Groupable {
             return CGRectZero
         }
 
-        return superview.frame
+        return superview.bounds
     }
 
     public func setDimensionAutomatically() {
@@ -148,6 +148,8 @@ public enum Edge {
 /// the horizontal center of the sibling's frame or centered horizontally within the superview, depending on the context.
 ///
 public enum Align {
+    case ToTheRightMatchingTopWrapping // ToTheRightMatchingTop
+    case UnderMatchingLeftFollowing // UnderMatchingLeft
     case ToTheRightMatchingTop
     case ToTheRightMatchingBottom
     case ToTheRightCentered

--- a/Source/NeonAlignable.swift
+++ b/Source/NeonAlignable.swift
@@ -44,6 +44,20 @@ public extension Alignable {
         var yOrigin : CGFloat = 0.0
 
         switch align {
+        case .ToTheRightMatchingTopWrapping:
+            xOrigin = sibling.xMax + padding
+            yOrigin = sibling.y + offset
+
+            if (xOrigin + self.width) > (self.superFrame.minX+self.superFrame.width) {
+                xOrigin = 0 + padding
+                yOrigin = sibling.yMax + padding
+            }
+
+        case .UnderMatchingLeftFollowing:
+            xOrigin = 0 + padding
+            yOrigin = sibling.yMax + padding
+
+
         case .ToTheRightMatchingTop:
             xOrigin = sibling.xMax + padding
             yOrigin = sibling.y + offset
@@ -167,6 +181,11 @@ public extension Alignable {
             yOrigin = sibling.yMax + padding
             width = superviewWidth - xOrigin - padding
 
+        case .UnderMatchingLeftFollowing:
+            xOrigin = 0 + padding + offset
+            yOrigin = sibling.yMax + padding
+            width = superviewWidth - xOrigin - padding
+
         case .UnderMatchingRight:
             xOrigin = padding + offset
             yOrigin = sibling.yMax + padding
@@ -191,6 +210,9 @@ public extension Alignable {
             xOrigin = padding + offset
             yOrigin = sibling.y - padding - height
             width = superviewWidth - (2 * padding)
+
+        case .ToTheRightMatchingTopWrapping:
+            fatalError("[NEON] Invalid Align specified for align().")
         }
 
         if width < 0.0 {
@@ -290,6 +312,9 @@ public extension Alignable {
             xOrigin = sibling.xMid - (width / 2.0) + offset
             yOrigin = padding
             height = sibling.y - (2 * padding)
+
+        case .UnderMatchingLeftFollowing, .ToTheRightMatchingTopWrapping:
+            fatalError("[NEON] Invalid Align specified for alignAndFillHeight().")
         }
 
         if height < 0.0 {
@@ -401,6 +426,9 @@ public extension Alignable {
             yOrigin = padding
             width = superviewWidth - (2 * padding)
             height = superviewHeight - (superviewHeight - sibling.y) - (2 * padding)
+
+        case .UnderMatchingLeftFollowing, .ToTheRightMatchingTopWrapping:
+            fatalError("[NEON] Invalid Align specified for alignAndFill().")
         }
 
         if width < 0.0 {
@@ -470,7 +498,7 @@ public extension Alignable {
             yOrigin = primaryView.yMid - (height / 2.0) + offset
             width = superviewWidth - secondaryView.xMax - (superviewWidth - primaryView.x) - (2 * padding)
 
-        case .UnderMatchingLeft, .UnderMatchingRight, .UnderCentered,  .AboveMatchingLeft, .AboveMatchingRight, .AboveCentered:
+        case .UnderMatchingLeft, .UnderMatchingRight, .UnderCentered,  .AboveMatchingLeft, .AboveMatchingRight, .AboveCentered, .UnderMatchingLeftFollowing, .ToTheRightMatchingTopWrapping:
             fatalError("[NEON] Invalid Align specified for alignBetweenHorizonal().")
         }
 
@@ -542,7 +570,7 @@ public extension Alignable {
             yOrigin = secondaryView.yMax + padding
             height = superviewHeight - secondaryView.yMax - (superviewHeight - primaryView.y) - (2 * padding)
 
-        case .ToTheLeftMatchingTop, .ToTheLeftMatchingBottom, .ToTheLeftCentered, .ToTheRightMatchingTop, .ToTheRightMatchingBottom, .ToTheRightCentered:
+        case .ToTheLeftMatchingTop, .ToTheLeftMatchingBottom, .ToTheLeftCentered, .ToTheRightMatchingTop, .ToTheRightMatchingBottom, .ToTheRightCentered, .UnderMatchingLeftFollowing, .ToTheRightMatchingTopWrapping:
             fatalError("[NEON] Invalid Align specified for alignBetweenVertical().")
         }
 

--- a/Source/NeonGroupable.swift
+++ b/Source/NeonGroupable.swift
@@ -383,6 +383,9 @@ public extension Groupable {
         case .AboveCentered:
             xOrigin = sibling.xMid - ((CGFloat(views.count) * width) + (CGFloat(views.count - 1) * padding)) / 2.0
             yOrigin = sibling.y - height - padding
+
+        case .UnderMatchingLeftFollowing, .ToTheRightMatchingTopWrapping:
+            fatalError("[NEON] Invalid Align specified for groupAndAlignHorizontal().")
         }
 
         for view in views {
@@ -450,6 +453,9 @@ public extension Groupable {
         case .AboveCentered:
             xOrigin = sibling.xMid - (width / 2.0)
             yOrigin = sibling.y - (CGFloat(views.count) * height) - (CGFloat(views.count) * padding)
+
+        case .UnderMatchingLeftFollowing, .ToTheRightMatchingTopWrapping:
+            fatalError("[NEON] Invalid Align specified for groupAndAlignVertical().")
         }
         
         for view in views {


### PR DESCRIPTION
Hi,

For certain scenarios I want to align components next to each other "to the right" while automatically wrapping to the next line if required. Different screen widths will allow a differing number of components to align next to each other.  The current pull request addresses this.  This does not logically apply in all scenarios.  Reactive web pages commonly address this and elastic changes can happen vertically but this change will keep this simple for now.

1. Add line wrapping capability utilizing .ToTheRightMatchingTopWrapping to indicate that a component aligned to another component on the right can wrap below and align itself to the left inside of the superview (+padding).

2. Add a newline capability to ensure that the newline anchor is relative to the end of the previous line which may be wrapped.  This uses .UnderMatchingLeftFollowing indicate that it must be under the tailing component to the left.   This is applicable to both align and alignAndFillWidth.

3. Updated the ViewController example with the necessary line wrapping examples showing both examples, with a subsequent alignAndFill.

4. Superview was using Frame instead of Bounds to determine the superview which is incorrect when the superview undergoes translations.  This was corrected.


![neon-flex](https://cloud.githubusercontent.com/assets/3245781/15373541/7ca69b64-1d46-11e6-8928-d12aaa5e90f5.gif)



