### PR TITLE
Moving UIView & CALayer extensions to a separate source file.

### DIFF
--- a/Neon.xcodeproj/project.pbxproj
+++ b/Neon.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		03EDD3C71BBF8CEC0006C4A9 /* ImageContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EDD3C01BBF8CEC0006C4A9 /* ImageContainerView.swift */; };
 		03EDD3C81BBF8CEC0006C4A9 /* TestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EDD3C21BBF8CEC0006C4A9 /* TestViewController.swift */; };
 		03EDD3C91BBF8CEC0006C4A9 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EDD3C31BBF8CEC0006C4A9 /* ViewController.swift */; };
+		52E7D6F71D520983007288D6 /* NeonExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E7D6F61D520983007288D6 /* NeonExtensions.swift */; };
+		52E7D6F81D520983007288D6 /* NeonExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E7D6F61D520983007288D6 /* NeonExtensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -87,6 +89,7 @@
 		03EDD3C21BBF8CEC0006C4A9 /* TestViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestViewController.swift; path = Demo/TestViewController.swift; sourceTree = SOURCE_ROOT; };
 		03EDD3C31BBF8CEC0006C4A9 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ViewController.swift; path = Demo/ViewController.swift; sourceTree = SOURCE_ROOT; };
 		27D253661BAF71AB00FA4FED /* Neon_Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Neon_Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		52E7D6F61D520983007288D6 /* NeonExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NeonExtensions.swift; path = Source/NeonExtensions.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -189,6 +192,7 @@
 			isa = PBXGroup;
 			children = (
 				03EDD3AE1BBF8BC90006C4A9 /* Neon.swift */,
+				52E7D6F61D520983007288D6 /* NeonExtensions.swift */,
 				03EDD3B11BBF8BC90006C4A9 /* NeonFrameable.swift */,
 				03EDD3B01BBF8BC90006C4A9 /* NeonAnchorable.swift */,
 				03EDD3AF1BBF8BC90006C4A9 /* NeonAlignable.swift */,
@@ -396,6 +400,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				03EDD3B31BBF8BC90006C4A9 /* Neon.swift in Sources */,
+				52E7D6F71D520983007288D6 /* NeonExtensions.swift in Sources */,
 				03EDD3BB1BBF8BCA0006C4A9 /* NeonGroupable.swift in Sources */,
 				03EDD3B91BBF8BCA0006C4A9 /* NeonFrameable.swift in Sources */,
 				03EDD3B51BBF8BCA0006C4A9 /* NeonAlignable.swift in Sources */,
@@ -408,6 +413,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				03EDD3B41BBF8BCA0006C4A9 /* Neon.swift in Sources */,
+				52E7D6F81D520983007288D6 /* NeonExtensions.swift in Sources */,
 				03EDD3BC1BBF8BCA0006C4A9 /* NeonGroupable.swift in Sources */,
 				03EDD3BA1BBF8BCA0006C4A9 /* NeonFrameable.swift in Sources */,
 				03EDD3B61BBF8BCA0006C4A9 /* NeonAlignable.swift in Sources */,

--- a/Source/Neon.swift
+++ b/Source/Neon.swift
@@ -6,51 +6,6 @@
 //  Copyright © 2015 Mike Amaral. All rights reserved.
 //
 
-#if os(iOS)
-  import UIKit
-  typealias View = UIView
-#else
-  import Cocoa
-  typealias View = NSView
-#endif
-
-
-// MARK: UIView implementation of the Neon protocols.
-//
-extension View : Frameable, Anchorable, Alignable, Groupable {
-    public var superFrame: CGRect {
-        guard let superview = superview else {
-            return CGRectZero
-        }
-
-        return superview.frame
-    }
-
-    public func setDimensionAutomatically() {
-        #if os(iOS)
-            self.sizeToFit()
-        #else
-            self.autoresizesSubviews = true
-            self.autoresizingMask = [.ViewWidthSizable, .ViewHeightSizable]
-        #endif
-    }
-}
-
-
-// MARK: CALayer implementation of the Neon protocols.
-//
-extension CALayer : Frameable, Anchorable, Alignable, Groupable {
-    public var superFrame: CGRect {
-        guard let superlayer = superlayer else {
-            return CGRectZero
-        }
-
-        return superlayer.frame
-    }
-
-    public func setDimensionAutomatically() { /* no-op here as this shouldn't apply to CALayers */ }
-}
-
 
 // MARK: AutoHeight
 //

--- a/Source/Neon.swift
+++ b/Source/Neon.swift
@@ -6,6 +6,12 @@
 //  Copyright © 2015 Mike Amaral. All rights reserved.
 //
 
+#if os(iOS)
+    import UIKit
+#else
+    import Cocoa
+#endif
+
 
 // MARK: AutoHeight
 //

--- a/Source/NeonExtensions.swift
+++ b/Source/NeonExtensions.swift
@@ -1,0 +1,51 @@
+//
+//  NeonExtensions.swift
+//  Neon
+//
+//  Created by Mike on 03/08/2016.
+//  Copyright © 2015 Mike Amaral. All rights reserved.
+//
+
+#if os(iOS)
+    import UIKit
+    typealias View = UIView
+#else
+    import Cocoa
+    typealias View = NSView
+#endif
+
+// MARK: UIView implementation of the Neon protocols.
+//
+extension View : Frameable, Anchorable, Alignable, Groupable {
+    public var superFrame: CGRect {
+        guard let superview = superview else {
+            return CGRectZero
+        }
+
+        return superview.frame
+    }
+
+    public func setDimensionAutomatically() {
+        #if os(iOS)
+            self.sizeToFit()
+        #else
+            self.autoresizesSubviews = true
+            self.autoresizingMask = [.ViewWidthSizable, .ViewHeightSizable]
+        #endif
+    }
+}
+
+
+// MARK: CALayer implementation of the Neon protocols.
+//
+extension CALayer : Frameable, Anchorable, Alignable, Groupable {
+    public var superFrame: CGRect {
+        guard let superlayer = superlayer else {
+            return CGRectZero
+        }
+
+        return superlayer.frame
+    }
+
+    public func setDimensionAutomatically() { /* no-op here as this shouldn't apply to CALayers */ }
+}


### PR DESCRIPTION
I'm using Neon in a Swift framework which implements a custom Window/View UI for OpenGL. I'd rather include Neon in my project as source code, rather than making Neon an additional dependency for clients of my framework.

The problem is that my own code defines "View", which conflicts with the typealias used in Neon to extend UIView/NSView (which I'm not using).

This change moves the UIView/NSView/CALayer extensions into a separate source file, which I can safely ignore when adding Neon to my project.

An alternative would obviously be to rename the typealias to something else ("KitView"?). But moving the extensions into a separate file seems cleaner to me.

PS: I'm loving Neon, a really elegant solution to layout :-)